### PR TITLE
Fixed case sensitivity for param argument

### DIFF
--- a/R/LLN_GLI.R
+++ b/R/LLN_GLI.R
@@ -23,9 +23,10 @@
 #' LLN_GLI(20:70, 1.7, 2, param=c("FEV1","FVC"))
 #'
 #' @importFrom stats reshape
-#' 
+#'
 #' @export
 LLN_GLI <- function(age, height, gender=1, ethnicity=1, param="FEV1") {
+  param <- toupper(param)
   dat <- getLMS(age, height, gender, ethnicity, param)
   dat$LLN <- with(dat, exp(log(1 - 1.645 * L * S)/L + log(M)))
 

--- a/R/LLN_NHANES3.R
+++ b/R/LLN_NHANES3.R
@@ -6,7 +6,7 @@
 #' @param age Age in years
 #' @param height Height in meters
 #' @param gender Gender (1 = male, 2 = female) or a factor with two levels (first = male). Default is 1.
-#' @param ethnicity Ethnicity (1 = Caucasian, 2 = African-American, 
+#' @param ethnicity Ethnicity (1 = Caucasian, 2 = African-American,
 #'   3 = Mexican-American). Default is 1.
 #' @param param A character vector, containing one of more of the following parameters (case insensitive):
 #' "FEV1", "FVC", "FEV1FVC", "PEF", "FEF2575", "FEV6", "FEV1FEV6"
@@ -24,15 +24,16 @@
 #'
 #' @export
 LLN_NHANES3 <- function(age, height, gender=1, ethnicity=1, param="FEV1") {
+  param <- toupper(param)
   param <- param[param %in% c("FEV1", "FVC", "FEV1FVC", "PEF", "FEF2575", "FEV6", "FEV1FEV6")]
   if (length(param)==0) stop("No valid parameters found in argument 'param'!")
-  
+
   dat <- rspiro_check_data(age, height, gender, ethnicity, NHANES=TRUE)
   dat$under20 <- dat$age<20
   dat$age2 <- dat$age^2
   dat$Intercept <- 1
   dat$height2 <- (dat$height * 100)^2
-  
+
   for (p in param) {
     if (p %in% c("FEV1FVC", "FEV1FEV6")) {
       cf <- t(mapply(function(p, gend, ethn) { NHtb6[
@@ -50,7 +51,7 @@ LLN_NHANES3 <- function(age, height, gender=1, ethnicity=1, param="FEV1") {
       dat[[paste0("pred.", p)]] <- unname(rowSums(dat[,c("Intercept","age","age2","height2")]*cf))
     }
   }
-  
+
   return(dat[,grep("pred", names(dat), fixed=TRUE)])
 
 }

--- a/R/pred_GLI.R
+++ b/R/pred_GLI.R
@@ -23,9 +23,10 @@
 #' LLN_GLI(20:70, 1.7, 2, param=c("FEV1","FVC"))
 #'
 #' @importFrom stats reshape
-#' 
+#'
 #' @export
 pred_GLI <- function(age, height, gender=1, ethnicity=1, param="FEV1") {
+  param <- toupper(param)
   dat <- getLMS(age, height, gender, ethnicity, param)
 
   datw <- reshape(dat[,c("id","f", "age","height","ethnicity","gender","M")],

--- a/R/pred_NHANES3.R
+++ b/R/pred_NHANES3.R
@@ -6,7 +6,7 @@
 #' @param age Age in years
 #' @param height Height in meters
 #' @param gender Gender (1 = male, 2 = female) or a factor with two levels (first = male). Default is 1.
-#' @param ethnicity Ethnicity (1 = Caucasian, 2 = African-American, 
+#' @param ethnicity Ethnicity (1 = Caucasian, 2 = African-American,
 #'   3 = Mexican-American). Default is 1.
 #' @param param A character vector, containing one of more of the following parameters (case insensitive):
 #' "FEV1", "FVC", "FEV1FVC", "PEF", "FEF2575", "FEV6", "FEV1FEV6"
@@ -24,15 +24,16 @@
 #'
 #' @export
 pred_NHANES3 <- function(age, height, gender=1, ethnicity=1, param="FEV1") {
+  param <- toupper(param)
   param <- param[param %in% c("FEV1", "FVC", "FEV1FVC", "PEF", "FEF2575", "FEV6", "FEV1FEV6")]
   if (length(param)==0) stop("No valid parameters found in argument 'param'!")
-  
+
   dat <- rspiro_check_data(age, height, gender, ethnicity, NHANES=TRUE)
   dat$under20 <- dat$age<20
   dat$age2 <- dat$age^2
   dat$Intercept <- 1
   dat$height2 <- (dat$height * 100)^2
-  
+
   for (p in param) {
     if (p %in% c("FEV1FVC", "FEV1FEV6")) {
       cf <- t(mapply(function(p, gend, ethn) { NHtb6[
@@ -50,7 +51,7 @@ pred_NHANES3 <- function(age, height, gender=1, ethnicity=1, param="FEV1") {
       dat[[paste0("pred.", p)]] <- unname(rowSums(dat[,c("Intercept","age","age2","height2")]*cf))
     }
   }
-  
+
   return(dat[,grep("pred", names(dat), fixed=TRUE)])
 
 }


### PR DESCRIPTION
The help documentation indicates that the `param` function is case-insensitive:
> A character vector, containing one of more of the following parameters (case insensitive): "FEV1", "FVC", "FEV1FVC", "FEF2575", "FEF75", "FEV075", "FEV075FVC"

However, `pred_GLI()`, `pred_NHANES3()`, `LLN_GLI()`, and `LLN_NHANES3()` failed if the `param` argument was anything but upper case. This PR provides a simple fix.