### PR TITLE
fixed input checking in zscore_GLI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,3 +23,6 @@ LazyData: true
 RoxygenNote: 7.1.1
 Depends: 
     R (>= 2.10)
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/R/zscores_GLI.R
+++ b/R/zscores_GLI.R
@@ -25,40 +25,53 @@
 #' stops with an error.
 #'
 #' @return If only one spirometry argument is supplied, the function
-#' returns a numeric vector. If more are supplied, the function returns 
+#' returns a numeric vector. If more are supplied, the function returns
 #' a data.frame with the same number of columns.
 #'
 #' @examples
 #' # Random data, 4 patients, one parameter supplied (FEV1)
-#' zscore_GLI(age=seq(25,40,5), height=c(1.8, 1.9, 1.75, 1.85),
-#'       gender=c(2,1,2,1), FEV1=c(3.5, 4, 3.6, 3.9))
+#' zscore_GLI(age=seq(25,40,4), height=c(1.8, 1.9, 1.75, 1.85),
+#'       gender=c(2,1,2,1), ethnicity=rep(1,4), FEV1=c(3.5, 4, 3.6, 3.9))
 #'
 #' @importFrom stats reshape
-#' 
+#'
 #' @export
 zscore_GLI <- function(age, height, gender=1, ethnicity=1,
         FEV1=NULL, FVC=NULL, FEV1FVC=NULL, FEF2575=NULL,
         FEF75=NULL, FEV075=NULL, FEV075FVC=NULL) {
-  val <- list(FEV1=FEV1, FVC=FVC, FEV1FVC=FEV1FVC, FEF2575=FEF2575,
+
+  spiro_val <- list(FEV1=FEV1, FVC=FVC, FEV1FVC=FEV1FVC, FEF2575=FEF2575,
               FEF75=FEF75, FEV075=FEV075, FEV075FVC=FEV075FVC)
-  val <- val[!sapply(val, is.null)]
-  param <- names(val)
-  if (length(val)==0)
+  spiro_val <- spiro_val[!sapply(spiro_val, is.null)]
+  somat_val <- list(age, height, gender, ethnicity)
+  spiro_val_len <- unique(sapply(spiro_val, length))
+  somat_val_len <- unique(sapply(somat_val, length))
+  stopifnot(is.numeric(age))
+  stopifnot(is.numeric(height))
+  if (length(spiro_val)==0)
     stop("At least one spirometry parameter must be specified.")
-  val_len <- unique(sapply(val, length))
-  if (length(val_len)>1)
-    stop("Not all spirometry parameter vactors have the same length.")
+  if (length(spiro_val_len)>1)
+    stop("Not all spirometry parameter vectors have the same length.")
+  if (length(somat_val_len)>1)
+    stop("Not all somatometric (age, height, gender, ethnicity) vectors have the same length.")
+  if ((somat_val_len!=1) && (somat_val_len!=spiro_val_len))
+    stop("If somatometric (age, height, gender, ethnicity) are not length 1, they must all be specified and be the same length as spirometry parameter vectors.")
+
+  if(!all(is.numeric(unlist(spiro_val)))){stop("Spirometry values must be numeric.")}
+  if (!(all(as.character(gender) %in% c('1','2')) || ((is.factor(gender) && (length(levels(gender))==2))))){stop("invalid value supplied for gender")}
+  if (is.factor(gender) && grepl('[fFwW]', levels(gender)[1])){message(sprintf("First level of factor gender ('%s') is assumed to be male.", levels(gender)[1]))}
+  if (!all(as.character(ethnicity) %in% c('1','2','3','4','5')) ){stop("invalid value supplied for ethnicity")}
+
+
+  param <- names(spiro_val)
   dat <- getLMS(age, height, gender, ethnicity, param)
-  if (nrow(dat)==1 && val_len>1) {
-    dat <- dat[rep(1,val_len),]
+  if (nrow(dat)==1 && spiro_val_len>1) {
+    dat <- dat[rep(1,spiro_val_len),]
     rownames(dat) <- NULL
     dat$id <- 1:nrow(dat)
   }
-  if (nrow(dat)!=val_len)
-    stop("Spirometry parameter vector(s) and somatometric vectors
-         (age, height, gender, ethnicity) do not have the same length.")
 
-  val <- as.data.frame.matrix(do.call(cbind, val))
+  val <- as.data.frame.matrix(do.call(cbind, spiro_val))
   val$id <- 1:nrow(val)
   val <- reshape(val, direction="long", varying=param, times=param, timevar="f", v.names="obs")
   dat <- merge(dat, val)

--- a/man/zscore_GLI.Rd
+++ b/man/zscore_GLI.Rd
@@ -44,7 +44,7 @@ zscore_GLI(
 }
 \value{
 If only one spirometry argument is supplied, the function
-returns a numeric vector. If more are supplied, the function returns 
+returns a numeric vector. If more are supplied, the function returns
 a data.frame with the same number of columns.
 }
 \description{
@@ -62,7 +62,7 @@ stops with an error.
 }
 \examples{
 # Random data, 4 patients, one parameter supplied (FEV1)
-zscore_GLI(age=seq(25,40,5), height=c(1.8, 1.9, 1.75, 1.85),
-      gender=c(2,1,2,1), FEV1=c(3.5, 4, 3.6, 3.9))
+zscore_GLI(age=seq(25,40,4), height=c(1.8, 1.9, 1.75, 1.85),
+      gender=c(2,1,2,1), ethnicity=rep(1,4), FEV1=c(3.5, 4, 3.6, 3.9))
 
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(rspiro)
+
+test_check("rspiro")

--- a/tests/testthat/test-zscores_GLI.R
+++ b/tests/testthat/test-zscores_GLI.R
@@ -1,0 +1,93 @@
+test_that("inputs are checked", {
+  # inconsistent length somatometric inputs
+  expect_error(
+    zscore_GLI(
+      age=rep(25,100), # too long
+      height=rep(1.5,5),
+      gender=rep(1,5),
+      ethnicity=rep(3,5),
+      FEV1=rep(1,5)),
+    "Not all somatometric (age, height, gender, ethnicity) vectors have the same length.",
+    fixed = TRUE
+  )
+  # somatometric length != spirometry length
+  expect_error(
+    zscore_GLI(
+      age=rep(25,5),
+      height=rep(1.5,5),
+      gender=rep(1,5),
+      ethnicity=rep(3,5),
+      FEV1=rep(1,100)), # too long
+    "If somatometric (age, height, gender, ethnicity) are not length 1, they must all be specified and be the same length as spirometry parameter vectors.",
+    fixed = TRUE
+  )
+  # no spirometry given
+  expect_error(
+    zscore_GLI(
+      age=seq(10,20,30),
+      height=c(1,1.5,2),
+      gender=c(1,1,1,1,1)),
+    "At least one spirometry parameter must be specified.",
+    fixed = TRUE
+  )
+  # non-numeric value for spiro
+  expect_error(
+    zscore_GLI(age = 10, height = 2, gender=1, ethnicity=3, FEV1='a character vector'),
+    "Spirometry values must be numeric.",
+    fixed = TRUE
+  )
+  # illegal value for gender
+  expect_error(
+    zscore_GLI(
+      age = 10,
+      height = 2,
+      gender='f', # character vector rather than factor/1/2
+      ethnicity=3,
+      FEV1=1),
+    "invalid value supplied for gender",
+    fixed = TRUE
+  )
+  # suspicious value for gender
+  expect_message(
+    zscore_GLI(
+      age = 10,
+      height = 2,
+      gender=factor('f', levels=c('f','m')), # 'f' supplied as first level of factor
+      ethnicity=3,
+      FEV1=1),
+    "First level of factor gender ('f') is assumed to be male.",
+    fixed = TRUE
+  )
+  expect_error( # illegal value for ethnicity
+    zscore_GLI(
+      age = 10,
+      height = 2,
+      gender=1,
+      ethnicity=27, # invalid
+      FEV1=1),
+    "invalid value supplied for ethnicity",
+    fixed = TRUE
+  )
+})
+
+test_that("correct value type returned", {
+  expect_type(
+    zscore_GLI(
+      age = 10,
+      height = 2,
+      gender=1,
+      ethnicity=4,
+      FEV1=1),
+    'double'
+  )
+  expect_s3_class(
+    zscore_GLI(
+      age = 10,
+      height = 2,
+      gender=1,
+      ethnicity=4,
+      FEV1=2,
+      FVC=3),
+    'data.frame'
+  )
+})


### PR DESCRIPTION
This PR includes changes to zscore_GLI.R's input checking to fix the issue I brought up here: https://github.com/thlytras/rspiro/issues/8. It also beefs up the input checking on that function and provides clearer error/warning messages to the user (hopefully). I implemented some testing to verify that these error messages are displayed as expected using testthat. 

I also fixed the example in the zscore_GLI documentation, which had a typo resulting in an error. 