### PR TITLE
Fixed error when gender missing to instead return missing

### DIFF
--- a/R/getLMS_GLIdiff.R
+++ b/R/getLMS_GLIdiff.R
@@ -47,7 +47,7 @@ getLMS_GLIdiff <- function(age, height, gender=1, param="TLCO", SI=TRUE) {
   
   # From here on we calculate the L,M,S according to different equations...
   
-  s <- dat$gender==1 & dat$f=="TLCO"
+  s <- dat$gender==1 & dat$f=="TLCO" & !is.na(dat$gender)
   if (SI) {
     dat$M[s] <- with(dat, exp(-8.129189 + 2.018368*log(height[s]*100) - 0.012425*log(age[s]) + Mspline[s]))
   } else {
@@ -56,7 +56,7 @@ getLMS_GLIdiff <- function(age, height, gender=1, param="TLCO", SI=TRUE) {
   dat$S[s] <- with(dat, exp(-1.98996 + 0.03536*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.39482
   
-  s <- dat$gender==1 & dat$f=="KCO"
+  s <- dat$gender==1 & dat$f=="KCO" & !is.na(dat$gender)
   if (SI) {
     dat$M[s] <- with(dat, exp(2.994137 - 0.415334*log(height[s]*100) - 0.113166*log(age[s]) + Mspline[s]))
   } else {
@@ -65,12 +65,12 @@ getLMS_GLIdiff <- function(age, height, gender=1, param="TLCO", SI=TRUE) {
   dat$S[s] <- with(dat, exp(-1.98186 + 0.01460*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.67330
   
-  s <- dat$gender==1 & dat$f=="VA"
+  s <- dat$gender==1 & dat$f=="VA" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-11.086573 + 2.430021*log(height[s]*100) + 0.097047*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.20953 + 0.01937*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.62559
     
-  s <- dat$gender==2 & dat$f=="TLCO"
+  s <- dat$gender==2 & dat$f=="TLCO" & !is.na(dat$gender)
   if (SI) {
     dat$M[s] <- with(dat, exp(-6.253720 + 1.618697*log(height[s]*100) - 0.015390*log(age[s]) + Mspline[s]))
   } else {
@@ -79,7 +79,7 @@ getLMS_GLIdiff <- function(age, height, gender=1, param="TLCO", SI=TRUE) {
   dat$S[s] <- with(dat, exp(-1.82905 - 0.01815*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.24160
   
-  s <- dat$gender==2 & dat$f=="KCO"
+  s <- dat$gender==2 & dat$f=="KCO" & !is.na(dat$gender)
   if (SI) {
     dat$M[s] <- with(dat, exp(4.037222 - 0.645656*log(height[s]*100) - 0.097395*log(age[s]) + Mspline[s]))
   } else {
@@ -88,7 +88,7 @@ getLMS_GLIdiff <- function(age, height, gender=1, param="TLCO", SI=TRUE) {
   dat$S[s] <- with(dat, exp(-1.63787 - 0.07757*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.48963
   
-  s <- dat$gender==2 & dat$f=="VA"
+  s <- dat$gender==2 & dat$f=="VA" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-9.873970 + 2.182316*log(height[s]*100) + 0.082868*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.08839 - 0.01334*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.51919

--- a/R/getLMS_GLIgl.R
+++ b/R/getLMS_GLIgl.R
@@ -40,32 +40,32 @@ getLMS_GLIgl <- function(age, height, gender=1, param="FEV1") {
   
   # From here on we calculate the L,M,S according to different equations...
   
-  s <- dat$gender==1 & dat$f=="FEV1"
+  s <- dat$gender==1 & dat$f=="FEV1" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-11.399108 + 2.462664*log(height[s]*100) - 0.011394*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.256278 + 0.080729*log(age[s]) + Sspline[s]))
   dat$L[s] <- 1.22703
   
-  s <- dat$gender==1 & dat$f=="FVC"
+  s <- dat$gender==1 & dat$f=="FVC" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-12.629131 + 2.727421*log(height[s]*100) + 0.009174*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.195595 + 0.068466*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.9346
   
-  s <- dat$gender==1 & dat$f=="FEV1FVC"
+  s <- dat$gender==1 & dat$f=="FEV1FVC" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(1.022608 - 0.218592*log(height[s]*100) - 0.027586*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.882025 + 0.068889*log(age[s]) + Sspline[s]))
   dat$L[s] <- with(dat, 3.8243 - 0.3328*log(age[s]))
   
-  s <- dat$gender==2 & dat$f=="FEV1"
+  s <- dat$gender==2 & dat$f=="FEV1" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-10.901689 + 2.385928*log(height[s]*100) - 0.076386*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.364047 + 0.129402*log(age[s]) + Sspline[s]))
   dat$L[s] <- 1.21388
   
-  s <- dat$gender==2 & dat$f=="FVC"
+  s <- dat$gender==2 & dat$f=="FVC" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-12.055901 + 2.621579*log(height[s]*100) - 0.035975*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.310148 + 0.120428*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.899
   
-  s <- dat$gender==2 & dat$f=="FEV1FVC"
+  s <- dat$gender==2 & dat$f=="FEV1FVC" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(0.9189568 - 0.1840671*log(height[s]*100) - 0.0461306*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-3.171582 + 0.144358*log(age[s]) + Sspline[s]))
   dat$L[s] <- with(dat, 6.6490 - 0.9920*log(age[s]))

--- a/R/getLMS_JRS.R
+++ b/R/getLMS_JRS.R
@@ -41,42 +41,42 @@ getLMS_JRS <- function(age, height, gender=1, param="FEV1") {
   
   # From here on we calculate the L,M,S according to different equations...
   
-  s <- dat$gender==1 & dat$f=="FEV1"
+  s <- dat$gender==1 & dat$f=="FEV1" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-7.5722 + 1.9393*log(height[s]*100) - 0.3068*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-3.0440 + 0.2325*log(age[s]) + Sspline[s]))
   dat$L[s] <- 1
   
-  s <- dat$gender==1 & dat$f=="FVC"
+  s <- dat$gender==1 & dat$f=="FVC" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-8.8877 + 2.1494*log(height[s]*100) - 0.1891*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.8335 + 0.1726*log(age[s]) + Sspline[s]))
   dat$L[s] <- 1
   
-  s <- dat$gender==1 & dat$f=="VC"
+  s <- dat$gender==1 & dat$f=="VC" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-8.8317 + 2.1043*log(height[s]*100) - 0.1382*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.3730 + 0.0450*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.3464
   
-  s <- dat$gender==1 & dat$f=="FEV1FVC"
+  s <- dat$gender==1 & dat$f=="FEV1FVC" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(1.2578 - 0.1948*log(height[s]*100) - 0.1220*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-3.266 + 0.150*log(age[s]) + Sspline[s]))
   dat$L[s] <- with(dat, 8.905 - 1.799*log(age[s]) + Lspline[s])
   
-  s <- dat$gender==2 & dat$f=="FEV1"
+  s <- dat$gender==2 & dat$f=="FEV1" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-6.9428 + 1.8053*log(height[s]*100) - 0.3401*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-3.1024 + 0.2537*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.7783
   
-  s <- dat$gender==2 & dat$f=="FVC"
+  s <- dat$gender==2 & dat$f=="FVC" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-8.3268 + 2.0137*log(height[s]*100) - 0.2029*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.8527 + 0.1881*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.6127
   
-  s <- dat$gender==2 & dat$f=="VC"
+  s <- dat$gender==2 & dat$f=="VC" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(-8.0707 + 1.9399*log(height[s]*100) - 0.1678*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-2.7071 + 0.1447*log(age[s]) + Sspline[s]))
   dat$L[s] <- 0.1268
   
-  s <- dat$gender==2 & dat$f=="FEV1FVC"
+  s <- dat$gender==2 & dat$f=="FEV1FVC" & !is.na(dat$gender)
   dat$M[s] <- with(dat, exp(1.2854 - 0.1844*log(height[s]*100) - 0.1425*log(age[s]) + Mspline[s]))
   dat$S[s] <- with(dat, exp(-3.1624 + 0.1068*log(age[s]) + Sspline[s]))
   dat$L[s] <- with(dat, 12.989 - 2.987*log(age[s]) + Lspline[s])

--- a/R/include.R
+++ b/R/include.R
@@ -89,7 +89,7 @@ rspiro_check_input <- function(spiro_val, somat_val) {
     stop("If somatometric (age, height, gender, ethnicity) are not length 1, they must all be specified and be the same length as spirometry z-score parameter vectors.")
   if(!all(is.numeric(unlist(spiro_val))))
     stop("Spirometry z-scores must be numeric.")
-  if (!(all(as.character(somat_val$gender) %in% c('1','2')) || ((is.factor(somat_val$gender) && (length(levels(somat_val$gender))==2)))))
+  if (!(all(as.character(somat_val$gender) %in% c('1','2', NA_character_)) || ((is.factor(somat_val$gender) && (length(levels(somat_val$gender))==2)))))
     stop("Invalid value supplied for gender")
   if (is.factor(somat_val$gender) && grepl('[fFwW]', levels(somat_val$gender)[1]))
     message(sprintf("First level of factor gender ('%s') is assumed to be male.", levels(somat_val$gender)[1]))

--- a/tests/testthat/test-zscores_GLI.R
+++ b/tests/testthat/test-zscores_GLI.R
@@ -36,6 +36,31 @@ test_that("inputs are checked", {
     "Spirometry z-scores must be numeric.",
     fixed = TRUE
   )
+
+  # missing gender returns missing without error
+  expect_no_error(
+    suppressWarnings(zscore_GLI(
+      age=seq(25,40,5), height=c(1.8, 1.9, 1.75, 1.85),
+      gender=c(2,1,2,NA_real_), FEV1=c(3.5, 4, 3.6, 3.9)))
+  )
+
+  expect_true(
+    is.na(suppressWarnings(zscore_GLI(
+      age=c(25), height=c(1.8),
+      gender=c(NA_real_), FEV1=c(3.5)))))
+
+  
+  expect_no_error(
+    suppressWarnings(zscore_GLIgl(
+      age=seq(25,40,5), height=c(1.8, 1.9, 1.75, 1.85),
+      gender=c(2,1,2,NA_real_), FEV1=c(3.5, 4, 3.6, 3.9)))
+  )
+
+  expect_true(
+    is.na(suppressWarnings(zscore_GLIgl(
+      age=c(25), height=c(1.8),
+      gender=c(NA_real_), FEV1=c(3.5)))))
+      
   # illegal value for gender
 #   expect_error(
 #     zscore_GLI(


### PR DESCRIPTION
This PR fixes the issue I brought up here: #17 so that the argument gender can have missing values without returning an error. This follows the behavior of the other input fields which when missing return missing values.

I added a few tests as well to capture the issue and demonstrate resolution.

